### PR TITLE
Use toast notification for login errors

### DIFF
--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import Seo from "@/components/seo/Seo";
 import heroImage from "@/assets/hero-finance.jpg";
+import { toast } from "sonner";
 
 const schema = z.object({
   email: z.string().email(),
@@ -20,8 +21,8 @@ type FormValues = z.infer<typeof schema>;
 const Login = () => {
   const { login, user } = useAuth();
   const navigate = useNavigate();
-  const location = useLocation() as any;
-  const from = location.state?.from?.pathname as string | undefined;
+  const location = useLocation();
+  const from = (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname;
 
   const {
     register,
@@ -43,7 +44,7 @@ const Login = () => {
 
   const onSubmit = async (values: FormValues) => {
     const { error } = await login(values.email, values.password, "signin");
-    if (error) return alert(error);
+    if (error) return toast.error(error.message);
   };
 
   return (


### PR DESCRIPTION
## Summary
- import `toast` from the existing Sonner utility
- replace `alert` with `toast.error` for login failures
- remove `any` cast from login location state

## Testing
- `npm test`
- `npm run lint` *(fails: 28 problems, 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d4a31bd08327a843942f0e72f7b4