### PR TITLE
feat: global error boundary + /health

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({ error }: { error: Error & { digest?: string } }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="text-lg font-semibold">Something went wrong.</h2>
+      <p>{error.message}</p>
+      {error.digest && <p>Digest: {error.digest}</p>}
+    </div>
+  );
+}

--- a/app/health/page.tsx
+++ b/app/health/page.tsx
@@ -1,0 +1,21 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  let db = 'skipped';
+
+  if (url && anonKey) {
+    const supabase = createClient(url, anonKey);
+    const { error } = await supabase.from('companies').select('id').limit(1);
+    db = error ? `error: ${error.message}` : 'ok';
+  }
+
+  return (
+    <pre>
+{`url: ${Boolean(url)}\nkey: ${Boolean(anonKey)}\ndb: ${db}`}
+    </pre>
+  );
+}


### PR DESCRIPTION
## Summary
- add client error boundary logging error digest
- add dynamic /health page that checks Supabase env vars and DB

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a62e16a298832799627d19068a87d4