### PR TITLE
feat(auth): login/register routes + navigation

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,61 @@
+import { redirect } from "next/navigation";
+import { supabaseAdmin } from "@/lib/supabase/server";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useFormState, useFormStatus } from "react-dom";
+
+async function login(
+  _prev: { error?: string },
+  formData: FormData
+): Promise<{ error?: string }> {
+  "use server";
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+  if (!email || !password) {
+    return { error: "Email and password are required" };
+  }
+  const supabase = supabaseAdmin();
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  if (error) {
+    return { error: error.message };
+  }
+  redirect("/(dashboard)");
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Logging in..." : "Login"}
+    </Button>
+  );
+}
+
+function LoginForm() {
+  const [state, formAction] = useFormState(login, { error: undefined });
+  return (
+    <form action={formAction} className="space-y-4 max-w-md">
+      <Input name="email" type="email" placeholder="Email" required />
+      <Input name="password" type="password" placeholder="Password" required />
+      {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+      <SubmitButton />
+      <p className="text-sm text-center text-muted-foreground">
+        Don't have an account? <Link href="/(auth)/register" className="underline">Register</Link>
+      </p>
+    </form>
+  );
+}
+
+export default function Page() {
+  return (
+    <div className="container py-8">
+      <h1 className="text-2xl font-semibold mb-6">Login</h1>
+      <LoginForm />
+    </div>
+  );
+}
+

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,58 @@
+import { redirect } from "next/navigation";
+import { supabaseAdmin } from "@/lib/supabase/server";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useFormState, useFormStatus } from "react-dom";
+
+async function register(
+  _prev: { error?: string },
+  formData: FormData
+): Promise<{ error?: string }> {
+  "use server";
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+  if (!email || !password) {
+    return { error: "Email and password are required" };
+  }
+  const supabase = supabaseAdmin();
+  const { error } = await supabase.auth.signUp({ email, password });
+  if (error) {
+    return { error: error.message };
+  }
+  redirect("/(dashboard)");
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending ? "Registering..." : "Register"}
+    </Button>
+  );
+}
+
+function RegisterForm() {
+  const [state, formAction] = useFormState(register, { error: undefined });
+  return (
+    <form action={formAction} className="space-y-4 max-w-md">
+      <Input name="email" type="email" placeholder="Email" required />
+      <Input name="password" type="password" placeholder="Password" required />
+      {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+      <SubmitButton />
+      <p className="text-sm text-center text-muted-foreground">
+        Already have an account? <Link href="/(auth)/login" className="underline">Login</Link>
+      </p>
+    </form>
+  );
+}
+
+export default function Page() {
+  return (
+    <div className="container py-8">
+      <h1 className="text-2xl font-semibold mb-6">Register</h1>
+      <RegisterForm />
+    </div>
+  );
+}
+

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -87,9 +87,14 @@ export const AppLayout = ({ title, children }: AppLayoutProps) => {
                   Logout
                 </Button>
               ) : (
-                <Button asChild variant="hero" size="sm">
-                  <Link to="/login">Login</Link>
-                </Button>
+                <>
+                  <Button asChild variant="outline" size="sm">
+                    <Link to="/(auth)/login">Login</Link>
+                  </Button>
+                  <Button asChild variant="hero" size="sm">
+                    <Link to="/(auth)/register">Register</Link>
+                  </Button>
+                </>
               )}
             </div>
             <div className="md:hidden">
@@ -121,16 +126,28 @@ export const AppLayout = ({ title, children }: AppLayoutProps) => {
                         </Button>
                       </SheetClose>
                     ) : (
-                      <SheetClose asChild>
-                        <Button
-                          asChild
-                          variant="hero"
-                          size="sm"
-                          className="mt-4"
-                        >
-                          <Link to="/login">Login</Link>
-                        </Button>
-                      </SheetClose>
+                      <>
+                        <SheetClose asChild>
+                          <Button
+                            asChild
+                            variant="outline"
+                            size="sm"
+                            className="mt-4"
+                          >
+                            <Link to="/(auth)/login">Login</Link>
+                          </Button>
+                        </SheetClose>
+                        <SheetClose asChild>
+                          <Button
+                            asChild
+                            variant="hero"
+                            size="sm"
+                            className="mt-2"
+                          >
+                            <Link to="/(auth)/register">Register</Link>
+                          </Button>
+                        </SheetClose>
+                      </>
                     )}
                   </nav>
                 </SheetContent>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,10 +39,13 @@ const Index = () => {
                 size="lg"
                 className="relative overflow-hidden"
               >
-                <Link to="/login">
+                <Link to="/(auth)/register">
                   <span className="pointer-events-none absolute inset-y-0 left-[-100%] w-1/3 bg-foreground/10 blur-md animate-shine" />
                   Get Started
                 </Link>
+              </Button>
+              <Button asChild variant="outline" size="lg">
+                <Link to="/(auth)/login">Login</Link>
               </Button>
               <Button asChild variant="outline" size="lg">
                 <a href="#features">Explore Features</a>


### PR DESCRIPTION
## Summary
- add login and register pages wired to Supabase auth
- link header and landing page CTAs to new auth routes

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a631e0266083279b438efd9b251474