### PR TITLE
feat(admin): requests approve/reject + loan creation

### DIFF
--- a/app/(dashboard)/admin/requests/actions.ts
+++ b/app/(dashboard)/admin/requests/actions.ts
@@ -1,0 +1,72 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { supabaseAdmin } from '@/lib/supabase/server'
+
+export async function approveRequest(requestId: string) {
+  const supabase = supabaseAdmin() as any
+
+  const { data: request, error: fetchError } = await supabase
+    .from('requests')
+    .select('*')
+    .eq('id', requestId)
+    .single()
+
+  if (fetchError || !request) {
+    throw new Error('Request not found')
+  }
+
+  const { error: updateError } = await supabase
+    .from('requests')
+    .update({ status: 'approved' })
+    .eq('id', requestId)
+
+  if (updateError) {
+    throw updateError
+  }
+
+  const { data: monthly, error: rpcError } = await supabase.rpc(
+    'calculate_monthly_payment',
+    {
+      principal_cents: request.amount_naira * 100,
+      annual_interest_rate: request.interest_rate,
+      duration_months: request.duration_months,
+    }
+  )
+
+  if (rpcError) {
+    throw rpcError
+  }
+
+  const { error: insertError } = await supabase.from('loans').insert({
+    request_id: request.id,
+    employee_id: request.employee_id,
+    principal_naira: request.amount_naira,
+    monthly_payment_naira: (monthly || 0) / 100,
+    duration_months: request.duration_months,
+    status: 'active',
+    outstanding_naira: request.amount_naira,
+  })
+
+  if (insertError) {
+    throw insertError
+  }
+
+  revalidatePath('/(dashboard)/admin/requests')
+}
+
+export async function rejectRequest(requestId: string) {
+  const supabase = supabaseAdmin() as any
+
+  const { error } = await supabase
+    .from('requests')
+    .update({ status: 'rejected' })
+    .eq('id', requestId)
+
+  if (error) {
+    throw error
+  }
+
+  revalidatePath('/(dashboard)/admin/requests')
+}
+

--- a/app/(dashboard)/admin/requests/page.tsx
+++ b/app/(dashboard)/admin/requests/page.tsx
@@ -1,0 +1,73 @@
+import { supabaseAdmin } from '@/lib/supabase/server'
+import { approveRequest, rejectRequest } from './actions'
+
+export const dynamic = 'force-dynamic'
+
+export default async function Page() {
+  const supabase = supabaseAdmin() as any
+  const { data: requests, error } = await supabase.from('requests').select('*')
+
+  if (error) {
+    return <div>Error loading requests</div>
+  }
+
+  return (
+    <div>
+      <h1>Requests</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Employee</th>
+            <th>Amount (₦)</th>
+            <th>Interest %</th>
+            <th>Duration (months)</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {requests?.map((r: any) => (
+            <tr key={r.id}>
+              <td>{r.employee_id}</td>
+              <td>{r.amount_naira}</td>
+              <td>{r.interest_rate}</td>
+              <td>{r.duration_months}</td>
+              <td>{r.status}</td>
+              <td>
+                {r.status === 'pending' && (
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <form
+                      action={async () => {
+                        'use server'
+                        try {
+                          await approveRequest(r.id)
+                        } catch (e) {
+                          console.error(e)
+                        }
+                      }}
+                    >
+                      <button type="submit">Approve</button>
+                    </form>
+                    <form
+                      action={async () => {
+                        'use server'
+                        try {
+                          await rejectRequest(r.id)
+                        } catch (e) {
+                          console.error(e)
+                        }
+                      }}
+                    >
+                      <button type="submit">Reject</button>
+                    </form>
+                  </div>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- list admin loan requests with approve/reject actions
- create loans and update request status on approval
- allow rejection of requests with status update

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a635fbfc5c832783a42acd3ba3e1c6